### PR TITLE
Add high-level API wrapper: Circdata

### DIFF
--- a/circonusapi/circonusapi.py
+++ b/circonusapi/circonusapi.py
@@ -65,7 +65,7 @@ class CirconusAPI(object):
     def __init__(self, token):
         self.debug = False # Set api.debug = True to enable debug messages
         self.hostname = 'api.circonus.com'
-        self.appname = 'Circus' # Set api.appname to use application token other than Circus
+        self.appname = 'python-circonusapi' # Set api.appname to use a different appname
         self.token = token
         self.endpoints = [
             'check_bundle',

--- a/circonusapi/circonusdata.py
+++ b/circonusapi/circonusdata.py
@@ -9,6 +9,9 @@ import math
 from datetime import datetime
 
 from . import circonusapi
+
+# At the time of this writing circllhist is not available on pip.
+# You can get it from: github.com/circonus-labs/libcircllhist/
 from circllhist import Circllhist
 
 FORMAT_FIELDS = [

--- a/circonusapi/circonusdata.py
+++ b/circonusapi/circonusdata.py
@@ -1,0 +1,280 @@
+"""
+Circonus Data Fetching API
+
+This module provides simplified methods for data fetching operations.
+To gain access to the full functionality use the circonusapi module.
+"""
+
+import math
+from datetime import datetime
+
+from . import circonusapi
+from circllhist import Circllhist
+
+FORMAT_FIELDS = [
+    "count",
+    "counter",
+    "counter2",
+    "counter2_stddev",
+    "counter_stddev",
+    "derivative",
+    "derivative2",
+    "derivative2_stddev",
+    "derivative_stddev",
+    "value",
+    "stddev",
+    "histogram",
+]
+HIST_STATES = ["active", "true"]
+NAN = float("nan")
+BIG_INT = 2 ** 64 - 1
+
+################################################################################
+## Helper Functions
+
+
+def _cid2check_id(cid):
+    return cid[len("/check/") :]
+
+
+def _iter_pages(api, method, endpoint, params=None, limit=BIG_INT):
+    "Merge paginated results into a single iterator"
+    params = params or {}
+    _from = 0
+    _size = min(1000, limit)
+    _count = 0
+    while True:
+        params["size"] = _size
+        params["from"] = _from
+        res = api.api_call(method, endpoint, params=params)
+        if not res:
+            break
+        for r in res:
+            _count += 1
+            if _count > limit:
+                break
+            yield r
+        _from += _size
+
+
+def _hist2kind(hist, kind):
+    if kind == "histogram":
+        return hist
+    if kind == "value":
+        return hist.mean()
+    if kind == "count":
+        return hist.count()
+    if kind == "stddev":
+        return hist.stddev()
+    return NAN
+
+
+def _extend(kind, count, lst):
+    if kind == "histogram":
+        lst += [Circllhist() for i in range(count - len(lst))]
+        return lst
+    else:
+        for i, y in enumerate(lst):
+            if not y:
+                lst[i] = NAN
+        lst += [NAN] * (count - len(lst))
+        return lst
+
+
+def _caql_infer_type(res):
+    if len(res[0]) >= 3 and isinstance(res[0][2], dict):
+        return "histogram"
+    else:
+        return "numeric"
+
+
+def _fix_time(start, period):
+    if isinstance(start, datetime):
+        return _fix_time(start.timestamp(), period)
+    if not start % period == 0:
+        raise Exception(
+            "start parameter {} is not divisible by period {}. Use e.g. {} instead.".format(
+                start, period, math.floor(start / period)
+            )
+        )
+    return start
+
+
+################################################################################
+## Classes
+
+
+def CirconusMetricFactory(api, rec):
+    "Create a suitable CirconusMetric object from an API result"
+    check_id = _cid2check_id(rec["_check"])
+    name = rec["_metric_name"]
+    if rec["_histogram"] in HIST_STATES:
+        return CirconusMetricHistogram(api, check_id, name)
+    return CirconusMetricNumeric(api, check_id, name)
+
+
+class CirconusMetric(object):
+    "Circonus Metric base class"
+
+    def __init__(self, api, check_id, name):
+        self._api = api
+        self._check_id = check_id
+        self._name = name
+
+    def __repr__(self):
+        return "CirconusMetric{{check_id={},name={}}}".format(
+            self._check_id, self._name
+        )
+
+    def name(self):
+        return self._name
+
+    def check_id(self):
+        return self._check_id
+
+
+class CirconusMetricNumeric(CirconusMetric):
+
+    def type(self):
+        return "numeric"
+
+    def fetch(self, start, period, count, kind):
+        "Fetch data from a numeric metric"
+        assert kind in FORMAT_FIELDS
+        if kind == "histogram":
+
+            def fmt(rec):
+                # raise Exception("Can't fetch histogram data from a numeric metric")
+                h = Circllhist()
+                if rec[kind]:
+                    h.insert(rec[kind])
+                return h
+
+        else:
+
+            def fmt(rec):
+                return rec[kind]
+
+        params = {
+            "type": "numeric",
+            "period": period,
+            "start": int(start),
+            "end": int(start + count * period),
+            "format": "object",
+            "format_fields": kind,
+        }
+        endpoint = "data/{}_{}".format(self._check_id, self._name)
+        data = self._api.api_call("GET", endpoint, params=params)["data"][:count]
+        return _extend(kind, count, list(map(fmt, data)))
+
+
+class CirconusMetricHistogram(CirconusMetric):
+
+    def type(self):
+        return "histogram"
+
+    def fetch(self, start, period, count, kind):
+        "Fetch data from a histogram metric"
+        assert kind in FORMAT_FIELDS
+        params = {
+            "type": "histogram",
+            "period": period,
+            "start": int(start),
+            "end": int(start + count * period),
+            "format": "object",
+        }
+
+        def fmt(rec):
+            return _hist2kind(Circllhist.from_dict(rec[2]), kind)
+
+        endpoint = "data/{}_{}".format(self._check_id, self._name)
+        data = self._api.api_call("GET", endpoint, params=params)["data"][:count]
+        return _extend(kind, count, list(map(fmt, data)))
+
+
+class CirconusMetricList(list):
+    """Holds multiple Circonus Metrics.
+    - Can be used like a list to access the individual member metrics
+    - __str__() returns a table formatted table representation
+    - fetch() can be used to fetch data
+    """
+
+    def fetch(self, start, period, count, kind="value"):
+        """
+        Fetch data from all metrics in the list.
+        Return result as map: metric_name => list
+        Fetches are done serially. Use CAQL for parallel data fetching.
+        """
+        start = _fix_time(start, period)
+        out = {}
+        out["time"] = [start + n * period for n in range(count)]
+        for metric in self:
+            key = "{}/{}".format(metric.check_id(), metric.name())
+            out[key] = metric.fetch(start, period, count, kind)
+        return out
+
+    def __repr__(self):
+        return "CirconusMetricList(len={})".format(len(self))
+
+    def __str__(self):
+        "Print metric List as table"
+
+        def fmt(m):
+            return "{:<10} {:<10} {:<50}".format(m.check_id(), m.type(), m.name())
+
+        return "\n".join(
+            ["check_id   type       metric_name", "-" * 50] + list(map(fmt, self))
+        )
+
+
+class CirconusData(object):
+    "Circonus data fetching class"
+
+    def __init__(self, token):
+        self._api = circonusapi.CirconusAPI(token)
+
+    def search(self, search="", kind=None, limit=BIG_INT):
+        """Search for metrics using the metric search API.
+        Returns a CirconusMetricList Object, that can be used to fetch data.
+        """
+        params = {"search": search}
+        fmt = lambda rec: CirconusMetricFactory(self._api, rec)
+        return CirconusMetricList(
+            map(
+                fmt,
+                _iter_pages(self._api, "GET", "/metric", params=params, limit=limit),
+            )
+        )
+
+    def caql(self, query, start, period, count):
+        """
+        Fetch data using CAQL.
+        Returns a map: slot_name => list
+        Limitations:
+        - slots_names are currently output[i]
+        - For histogram output only a single slot is returned
+        """
+        start = _fix_time(start, period)
+        params = {
+            "query": query,
+            "period": period,
+            "start": int(start),
+            "end": int(start + count * period),
+        }
+        res = self._api.api_call("GET", "/caql", params=params)["_data"]
+        if _caql_infer_type(res) == "histogram":
+            # In this case, we have only a single output metric and res looks like:
+            # res = [[1467892920, 60, {'1.2e+02': 1, '2': 1, '1': 1}], ... ]
+            return {
+                "time": [row[0] for row in res],
+                "output[0]": [Circllhist.from_dict(row[2]) for row in res],
+            }
+        else:
+            # In the numeric case res looks like this:
+            # res = [[1467892920, [1, 2, 3]], [1467892980, [1, 2, 3]], ... ]
+            out = {}
+            width = len(res[0][1])
+            out["time"] = [row[0] for row in res]
+            for i in range(width):
+                out["output[{}]".format(i)] = [row[1][i] for row in res]
+            return out

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ setup (
     name="circonusapi",
     version="0.2.5",
     description="Circonus API library",
-    author="Mark Harrison",
-    author_email="mark@omniti.com",
-    url="http://github.com/omniti-labs/circonusapi",
+    maintainer="Heinrich Hartmann",
+    maintainer_email="heinrich.hartmann@circonus.com",
+    url="https://github.com/circonus-labs/python-circonusapi",
     license="ISC",
     classifiers=[
         "Programming Language :: Python",

--- a/test_circonusapi.py
+++ b/test_circonusapi.py
@@ -5,15 +5,15 @@ Example:
 
 CIRCONUS_CONFIG=/tmp/test_circonus_config.ini tox
 
-
+The config file must contain a valid token for the Circonus demo account.
 '''
 import os
 
 from tempfile import NamedTemporaryFile
+import unittest
 from unittest import TestCase
 
 from circonusapi import circonusapi, config
-
 
 class ConfigTestCase(TestCase):
 
@@ -97,15 +97,15 @@ class CirconusAPITestCase(TestCase):
 
     def test_data_endpoint(self):
         result = self.api.get_data(
-            '159841_available',
+            '160764_services',
             params=dict(
                 type='numeric',
-                start=1362400895,
-                end=1362487307,
+                start=1514764800,
+                end=1514767800,
                 period=300
             )
         )
-        self.assertTrue(len(result.get('data')) > 20) 
+        self.assertTrue(len(result.get('data')) == 10)
 
     def test_data_wrong_format(self):
         '''
@@ -129,3 +129,5 @@ class CirconusAPITestCase(TestCase):
         for bundle in dns_bundles:
             self.assertEqual(bundle.get('type'), 'dns')
 
+if __name__ == '__main__':
+    unittest.main()

--- a/test_circonusdata.py
+++ b/test_circonusdata.py
@@ -1,0 +1,37 @@
+"""
+Test for the circonusdata module
+"""
+#
+# circonusdata.py depends on circllhist being available. As this dependency is currently not
+# installable via pip we keep these tests in a separate file.
+#
+import os
+from datetime import datetime
+
+import unittest
+from unittest import TestCase
+
+from circonusapi import circonusdata, config
+
+class CirconusAPITestCase(TestCase):
+
+    def setUp(self):
+        config_file = os.environ.get('CIRCONUS_CONFIG')
+        cfg = config.load_config(configfile=config_file, nocache=True)
+        account = cfg.get('general', 'default_account')
+        token = cfg.get('tokens', account)
+        api = circonusdata.CirconusData(token)
+        self.api = api
+
+    def test_search(self):
+        m = self.api.search("(check_id:160764) (metric:services)")
+        self.assertEqual(len(m), 1)
+        r = m.fetch(datetime(2018,1,1),60,10)
+        self.assertEqual(len(r['time']), 10)
+
+    def test_caql(self):
+        c = self.api.caql("search:metric('(check_id:160764) (metric:services)')", datetime(2018,1,1), 60, 10)
+        self.assertEqual(len(c['time']), 10)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The Classes in the circdata module allow convenient access to the most common data fetching operations:
- Search for metrics + fetch data via the `/metrics` and `/data` API endpoints
- CAQL via `/caql`

The output of this methods can directly be passed to pandas for further analysis.
Histogram output is supported. A blog post/examples on how to appy this functions is forthcoming.

An effort is made to treat histogram and numeric values on equal footing. When a search results sets are hybrid numeric/histogram we convert the output to the requested kind.

The circdata module depends on circllhist to be available on the system.
At the time of this writing circllhist can't be installed via pip, so we stay away from making it a dependency in setup.py.

I am not sure how to best deal with dependencies of optional additions like circdata.py.
Even without circllhist, the CirconusAPI class is fully usable.