### PR TITLE
Use datetime.now() to obtain timestamp

### DIFF
--- a/circonusapi/circonussubmit.py
+++ b/circonusapi/circonussubmit.py
@@ -35,6 +35,7 @@ import sys
 import random
 import string
 import requests
+import time
 from datetime import datetime
 
 from . import circonusapi
@@ -116,7 +117,7 @@ class CirconusSubmit(object):
 
     def _add(self, ts, name, data):
         if ts == "now":
-            ts = datetime.utcnow().timestamp()
+            ts = int(time.time())
         if isinstance(ts, datetime):
             ts = ts.timestamp()
         data['_ts'] = int( ts * 1000 ) # convert to ms

--- a/circonusapi/circonussubmit.py
+++ b/circonusapi/circonussubmit.py
@@ -35,8 +35,7 @@ import sys
 import random
 import string
 import requests
-import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 from . import circonusapi
 #
@@ -117,7 +116,7 @@ class CirconusSubmit(object):
 
     def _add(self, ts, name, data):
         if ts == "now":
-            ts = int(time.time())
+            ts = datetime.now(tz=timezone.utc).timestamp()
         if isinstance(ts, datetime):
             ts = ts.timestamp()
         data['_ts'] = int( ts * 1000 ) # convert to ms


### PR DESCRIPTION
datetime.utcnow().timestamp() should not be used to obtain utc time. Python can get confused between the systems timezone and the environment.

This patch explicitly calls for a current timestamp in utc.